### PR TITLE
Testing wagtail 5 upgrade

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         include:
           - python: 3.9
-            wagtail: wagtail>=4.1,<5.0
+            wagtail: wagtail>=4.1,<5.1
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,6 @@ name: Tests
 
 on:
   push:
-    branches: [master]
   pull_request:
     branches: [master]
 


### PR DESCRIPTION
There is a PR back to the owner repo here: https://github.com/kevinhowbrook/wagtailguide/pull/24

Please use this branch as a source dependency until the PR above is accepted.

### Close this PR once the PR above is merged and a new release is available.