### PR TITLE
Support/wagtail 5.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,10 @@ jobs:
         include:
           - python: 3.9
             wagtail: wagtail>=4.1,<5.1
+          - python: 3.9
+            wagtail: wagtail>=4.2,<5.0
+          - python: 3.9
+            wagtail: wagtail>=5.0,<5.1
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,9 @@ on:
     branches: [master]
 
 # Current configuration:
-# - python 3.9, wagtail 4.1
+# - python 3.9, django 3.2, wagtail 4.1
+# - python 3.9, django 4.1, wagtail 4.2
+# - python 3.9, django 4.2, wagtail 5.0
 
 jobs:
   lint:
@@ -36,12 +38,41 @@ jobs:
     strategy:
       matrix:
         include:
-          - python: 3.9
-            wagtail: wagtail>=4.1,<5.1
-          - python: 3.9
+          - python: "3.9"
+            django: django>=3.2,<4.0
+            wagtail: wagtail>=4.1,<4.2
+          - python: "3.9"
+            django: django>=4.1,<4.2
             wagtail: wagtail>=4.2,<5.0
-          - python: 3.9
+          - python: "3.9"
+            django: django>=4.2,<4.3
             wagtail: wagtail>=5.0,<5.1
+          - python: "3.9"
+            django: django>=4.2,<4.3
+            wagtail: wagtail>=5.1,<5.2
+
+          - python: "3.10"
+            django: django>=3.2,<4.0
+            wagtail: wagtail>=4.1,<4.2
+          - python: "3.10"
+            django: django>=4.1,<4.2
+            wagtail: wagtail>=4.2,<5.0
+          - python: "3.10"
+            django: django>=4.2,<4.3
+            wagtail: wagtail>=5.0,<5.1
+          - python: "3.10"
+            django: django>=4.2,<4.3
+            wagtail: wagtail>=5.1,<5.2
+
+          - python: "3.11"
+            django: django>=4.1,<4.2
+            wagtail: wagtail>=4.2,<5.0
+          - python: "3.11"
+            django: django>=4.2,<4.3
+            wagtail: wagtail>=5.0,<5.1
+          - python: "3.11"
+            django: django>=4.2,<4.3
+            wagtail: wagtail>=5.1,<5.2
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/wagtail_guide/tests/settings.py
+++ b/wagtail_guide/tests/settings.py
@@ -77,3 +77,5 @@ WAGTAIL_GUIDE_SETTINGS = {
     "WAGTAIL_GUIDE_MENU_LABEL": "WG guide menu label",
     "HIDE_WAGTAIL_CORE_EDITOR_GUIDE": True,
 }
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"


### PR DESCRIPTION
# Wagtail 5.1 update

There are no changes required to this package for Wagtail 5.1 support.

But I did boost the testing and added some extra version to the matrix.

The current release version should work fine with Wagtail v5.1